### PR TITLE
Add listeners to the start end end events of the game

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -151,6 +151,16 @@ describe('TypeRacer Methods', () => {
         expect(typeRacer.isRunning).toBe(false);
         expect(typeRacer.isOver).toBe(true);
     });
+
+    test('The game informs if it has started by calling the onGameStart closure', done => {
+        const typeRacer = new TypeRacer('test');
+        typeRacer.onGameStart = () => {
+            expect(typeRacer.isRunning).toBe(true);
+            done();
+        };
+        
+        typeRacer.start();
+    });
 });
 
 describe('TypeRacer constructor', () => {
@@ -202,7 +212,15 @@ describe('TypeRacer constructor', () => {
 
     test('initiates with its seconds checker set to null', () => {
         expect((new TypeRacer('test')).secondsChecker).toBeNull();
-    })
+    });
+
+    test('initiates with an onGameStart closure event handler set to null', () => {
+        expect((new TypeRacer('test')).onGameStart).toBeNull();
+    });
+
+    test('initiates with an onGameOver closure event handler set to null', () => {
+        expect((new TypeRacer('test')).onGameOver).toBeNull();
+    });
 });
 
 describe('TypingDisplayer', () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -161,6 +161,41 @@ describe('TypeRacer Methods', () => {
         
         typeRacer.start();
     });
+
+    test('The game informs if it has ended by calling the onGameOver closure when time ends', done => {
+        const typeRacer = new TypeRacer('test');
+        typeRacer.onGameOver = () => {
+            expect(typeRacer.isRunning).toBe(false);
+            expect(typeRacer.isOver).toBe(true);
+            done();
+        };
+        
+        typeRacer.start();
+        // Make the game end by setting its time.
+        typeRacer.setTime(89);
+    });
+
+    test('The game ends if the player types the whole text and it\'s matched', done => {
+        const typeRacer = new TypeRacer('test game ending');
+        typeRacer.onGameOver = () => {
+            expect(typeRacer.isOver).toBe(true);
+            expect(typeRacer.isRunning).toBe(false);
+
+            expect(typeRacer.currentPlayer.typedWords.length).toBe(3);
+
+            done();
+        };
+        typeRacer.start();
+
+        typeRacer.setTypingText('test ');
+        typeRacer.match();
+
+        typeRacer.setTypingText('game ');
+        typeRacer.match();
+
+        typeRacer.setTypingText('ending');
+        typeRacer.match();
+    });
 });
 
 describe('TypeRacer constructor', () => {

--- a/typeracer.js
+++ b/typeracer.js
@@ -98,9 +98,21 @@ class TypeRacer {
     start() {
         this.isRunning = true;
         this.secondsChecker = new SecondsChecker(Date.now(), Date.now() + 60);
-        
+
         if (typeof this.onGameStart === 'function') {
             this.onGameStart();
+        }
+    }
+
+    /**
+     * Ends the game, by calling its end closure reference, if there's one.
+     */
+    end() {
+        this.isOver = true;
+        this.isRunning = false;
+
+        if (typeof this.onGameOver === 'function') {
+            this.onGameOver();
         }
     }
 
@@ -110,8 +122,9 @@ class TypeRacer {
      * @param {Number} seconds - the amount of seconds since the game began.
      */
     setTime(seconds) {
-        this.isOver = this.secondsChecker.passesEndTime(seconds);
-        this.isRunning = !this.isOver;
+        if (this.secondsChecker.passesEndTime(seconds)) {
+            this.end();
+        }
     }
 
     /**
@@ -183,6 +196,10 @@ class TypeRacer {
         if (matches) {
             this.currentPlayer.typingText = '';
             this.currentPlayer.typedWords.push(word);
+
+            if (this.getRemainingText().length === 0) {
+                this.end();
+            }
         }
 
         return matches;
@@ -200,7 +217,7 @@ class SecondsChecker {
     constructor(startTime, endTime) {
         for (let i = 0; i < arguments.length; i++) {
             const argument = arguments[i];
-    
+
             if (typeof argument !== 'number' || isNaN(argument)) {
                 throw new TypeError('The passed date must be a valid time interval');
             }

--- a/typeracer.js
+++ b/typeracer.js
@@ -70,12 +70,22 @@ class TypeRacer {
          * Flag indicating if the game is started or not.
          */
         this.isRunning = false;
-    
+
+        /**
+         * A closure reference called to inform the game has just started.
+         */
+        this.onGameStart = null;
+
         /**
          * Flag indicating if hte is over.
          */
         this.isOver = false;
-    
+
+        /**
+         * A closure reference called when the game has just ended.
+         */
+        this.onGameOver = null;
+
         /**
          * The object in charge of checking if the race time is over.
          */
@@ -88,6 +98,10 @@ class TypeRacer {
     start() {
         this.isRunning = true;
         this.secondsChecker = new SecondsChecker(Date.now(), Date.now() + 60);
+        
+        if (typeof this.onGameStart === 'function') {
+            this.onGameStart();
+        }
     }
 
     /**


### PR DESCRIPTION
The game now has `onStartGame` and `onGameOver` closures to be called when those game events happen. The listening object can then have a chance to take action.